### PR TITLE
Support Ruby 3

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.6', '2.5', '2.4' ]
+        ruby: [ '3.0', '2.7', '2.6', '2.5', '2.4' ]
     steps:
       - uses: actions/checkout@master
       - name: Checkout submodules

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.6', '2.5', '2.4' ]
+        ruby: [ '3.0', '2.7', '2.6', '2.5', '2.4' ]
     steps:
       - uses: actions/checkout@master
       - name: Checkout submodules

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.6', '2.5', '2.4' ]
+        ruby: [ '3.0', '2.7', '2.6', '2.5', '2.4' ]
     steps:
       - uses: actions/checkout@master
       - name: Checkout submodules

--- a/lib/relaton_bib/bibliographic_item.rb
+++ b/lib/relaton_bib/bibliographic_item.rb
@@ -197,23 +197,23 @@ module RelatonBib
       @title = TypedTitleStringCollection.new(args[:title])
 
       @date = (args[:date] || []).map do |d|
-        d.is_a?(Hash) ? BibliographicDate.new(d) : d
+        d.is_a?(Hash) ? BibliographicDate.new(**d) : d
       end
 
       @contributor = (args[:contributor] || []).map do |c|
         if c.is_a? Hash
-          e = c[:entity].is_a?(Hash) ? Organization.new(c[:entity]) : c[:entity]
+          e = c[:entity].is_a?(Hash) ? Organization.new(**c[:entity]) : c[:entity]
           ContributionInfo.new(entity: e, role: c[:role])
         else c
         end
       end
 
       @abstract = (args[:abstract] || []).map do |a|
-        a.is_a?(Hash) ? FormattedString.new(a) : a
+        a.is_a?(Hash) ? FormattedString.new(**a) : a
       end
 
       @copyright = args.fetch(:copyright, []).map do |c|
-        c.is_a?(Hash) ? CopyrightAssociation.new(c) : c
+        c.is_a?(Hash) ? CopyrightAssociation.new(**c) : c
       end
 
       @docidentifier  = args[:docid] || []
@@ -229,7 +229,7 @@ module RelatonBib
       @status         = args[:docstatus]
       @relation       = DocRelationCollection.new(args[:relation] || [])
       @link           = args.fetch(:link, []).map do |s|
-        if s.is_a?(Hash) then TypedUri.new(s)
+        if s.is_a?(Hash) then TypedUri.new(**s)
         elsif s.is_a?(String) then TypedUri.new(content: s)
         else s
         end

--- a/lib/relaton_bib/copyright_association.rb
+++ b/lib/relaton_bib/copyright_association.rb
@@ -30,7 +30,7 @@ module RelatonBib
       end
 
       @owner = owner.map do |o|
-        o.is_a?(Hash) ? ContributionInfo.new(entity: Organization.new(o)) : o
+        o.is_a?(Hash) ? ContributionInfo.new(entity: Organization.new(**o)) : o
       end
 
       @from  = Date.strptime(from.to_s, "%Y") if from.to_s.match? /\d{4}/

--- a/lib/relaton_bib/document_relation_collection.rb
+++ b/lib/relaton_bib/document_relation_collection.rb
@@ -18,7 +18,7 @@ module RelatonBib
     #                   RelatonBib::SourceLocalityStack>] :source_locality
     # @option relation [RelatonBib::BibliographicItem, NillClass] :bibitem (nil)
     def initialize(relation)
-      @array = relation.map { |r| r.is_a?(Hash) ? DocumentRelation.new(r) : r }
+      @array = relation.map { |r| r.is_a?(Hash) ? DocumentRelation.new(**r) : r }
     end
 
     # @todo We don't have replace type anymore. Suppose we should update this

--- a/lib/relaton_bib/document_status.rb
+++ b/lib/relaton_bib/document_status.rb
@@ -54,7 +54,7 @@ module RelatonBib
     # @return [RelatonBib::DocumentStatus::Stage]
     def stage_new(stg)
       if stg.is_a?(Stage) then stg
-      elsif stg.is_a?(Hash) then Stage.new(stg)
+      elsif stg.is_a?(Hash) then Stage.new(**stg)
       elsif stg.is_a?(String) then Stage.new(value: stg)
       end
     end

--- a/lib/relaton_bib/hash_converter.rb
+++ b/lib/relaton_bib/hash_converter.rb
@@ -97,7 +97,7 @@ module RelatonBib
         return unless ret[:place]
 
         ret[:place] = array(ret[:place]).map do |pl|
-          pl.is_a?(String) ? Place.new(name: pl) : Place.new(pl)
+          pl.is_a?(String) ? Place.new(name: pl) : Place.new(**pl)
         end
       end
 
@@ -146,7 +146,7 @@ module RelatonBib
         ret[:biblionote] = array(ret[:biblionote])
           .reduce(BiblioNoteCollection.new([])) do |mem, n|
           mem << if n.is_a?(String) then BiblioNote.new content: n
-                 else BiblioNote.new(n)
+                 else BiblioNote.new(**n)
                  end
         end
       end
@@ -247,10 +247,10 @@ module RelatonBib
                       script: d[:script], format: d[:format] }
                   else { content: d }
                   end
-            FormattedString.new cnt
+            FormattedString.new **cnt
           end
           Affiliation.new(
-            organization: Organization.new(org_hash_to_bib(a[:organization])),
+            organization: Organization.new(**org_hash_to_bib(a[:organization])),
             description: a[:description]
           )
         end
@@ -288,7 +288,7 @@ module RelatonBib
         ret[:relation] = array(ret[:relation])
         ret[:relation]&.each do |r|
           if r[:description]
-            r[:description] = FormattedString.new r[:description]
+            r[:description] = FormattedString.new **r[:description]
           end
           relation_bibitem_hash_to_bib(r)
           relation_locality_hash_to_bib(r)
@@ -309,7 +309,7 @@ module RelatonBib
       # @param item_hash [Hash]
       # @return [RelatonBib::BibliographicItem]
       def bib_item(item_hash)
-        BibliographicItem.new item_hash
+        BibliographicItem.new **item_hash
       end
 
       # @param rel [Hash] relation
@@ -356,26 +356,26 @@ module RelatonBib
           end
           s[:abbreviation] &&
             s[:abbreviation] = localizedstring(s[:abbreviation])
-          Series.new(s)
+          Series.new(**s)
         end
       end
 
       # @param title [Hash]
       # @return [RelatonBib::TypedTitleString]
       def typed_title_strig(title)
-        TypedTitleString.new title
+        TypedTitleString.new **title
       end
 
       # @param ret [Hash]
       def medium_hash_to_bib(ret)
-        ret[:medium] = Medium.new(ret[:medium]) if ret[:medium]
+        ret[:medium] = Medium.new(**ret[:medium]) if ret[:medium]
       end
 
       # @param ret [Hash]
       def classification_hash_to_bib(ret)
         if ret[:classification]
           ret[:classification] = array(ret[:classification]).map do |cls|
-            Classification.new cls
+            Classification.new **cls
           end
         end
       end
@@ -409,7 +409,7 @@ module RelatonBib
         return unless ret[:editorialgroup]
 
         technical_committee = array(ret[:editorialgroup]).map do |wg|
-          TechnicalCommittee.new WorkGroup.new(wg)
+          TechnicalCommittee.new WorkGroup.new(**wg)
         end
         ret[:editorialgroup] = EditorialGroup.new technical_committee
       end
@@ -418,7 +418,7 @@ module RelatonBib
       def ics_hash_to_bib(ret)
         return unless ret[:ics]
 
-        ret[:ics] = array(ret[:ics]).map { |ics| ICS.new ics }
+        ret[:ics] = array(ret[:ics]).map { |ics| ICS.new **ics }
       end
 
       # @param ret [Hash]
@@ -427,7 +427,7 @@ module RelatonBib
 
         sids = array(ret[:structuredidentifier]).map do |si|
           si[:agency] = array si[:agency]
-          StructuredIdentifier.new si
+          StructuredIdentifier.new **si
         end
         ret[:structuredidentifier] = StructuredIdentifierCollection.new sids
       end
@@ -485,7 +485,7 @@ module RelatonBib
       # @return [RelatonBib::FormattedRef]
       def formattedref(frf)
         if frf.is_a?(Hash)
-          RelatonBib::FormattedRef.new(frf)
+          RelatonBib::FormattedRef.new(**frf)
         else
           RelatonBib::FormattedRef.new(content: frf)
         end

--- a/lib/relaton_bib/typed_title_string.rb
+++ b/lib/relaton_bib/typed_title_string.rb
@@ -8,7 +8,7 @@ module RelatonBib
     # @param title [Array<RelatonBib::TypedTitleString, Hash>]
     def initialize(title = [])
       @array = (title || []).map do |t|
-        t.is_a?(Hash) ? TypedTitleString.new(t) : t
+        t.is_a?(Hash) ? TypedTitleString.new(**t) : t
       end
     end
 
@@ -96,7 +96,7 @@ module RelatonBib
         fsargs = args.select do |k, _v|
           %i[content language script format].include? k
         end
-        @title = FormattedString.new(fsargs)
+        @title = FormattedString.new(**fsargs)
       end
     end
 

--- a/lib/relaton_bib/xml_parser.rb
+++ b/lib/relaton_bib/xml_parser.rb
@@ -376,7 +376,7 @@ module RelatonBib
       # @param item_hash [Hash]
       # @return [RelatonBib::BibliographicItem]
       def bib_item(item_hash)
-        BibliographicItem.new item_hash
+        BibliographicItem.new **item_hash
       end
 
       # @param rel [Nokogiri::XML::Element]

--- a/relaton-bib.gemspec
+++ b/relaton-bib.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "simplecov"
 
   spec.add_dependency "addressable"
-  spec.add_dependency "bibtex-ruby"
+  spec.add_dependency "bibtex-ruby", "~> 6.0"
   spec.add_dependency "iso639"
   spec.add_dependency "nokogiri"
 end

--- a/spec/relaton_bib/bibliographic_item_spec.rb
+++ b/spec/relaton_bib/bibliographic_item_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "RelatonBib" => :BibliographicItem do
       hash = YAML.load_file "spec/examples/bib_item.yml"
       hash_bib = RelatonBib::HashConverter.hash_to_bib hash
 
-      RelatonBib::BibliographicItem.new(hash_bib)
+      RelatonBib::BibliographicItem.new(**hash_bib)
     end
 
     it "is instance of BibliographicItem" do
@@ -120,7 +120,7 @@ RSpec.describe "RelatonBib" => :BibliographicItem do
     it "deals with hashes" do
       file = "spec/examples/bib_item.yml"
       h = RelatonBib::HashConverter.hash_to_bib(YAML.load_file(file))
-      b = RelatonBib::BibliographicItem.new(h)
+      b = RelatonBib::BibliographicItem.new(**h)
       expect(b.to_xml).to be_equivalent_to subject.to_xml
     end
 


### PR DESCRIPTION
This pull request adds Ruby 3.0 compatibility, or at least makes tests passing locally. It's likely that other Relaton gems require changes too. I was experimenting with Ruby 3.0 compatibility on this gem only.

The only significant change is that double splat operator (`**`) is used when passing a hash to a method which expects keyword arguments rather than actual hash. This is required because Ruby 3.0 no longer decomposes such hashes implicitly (see https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).

I am not sure if these are the only required changes, but they are enough to make tests passing.

Neither I'm sure if all these methods really should accept keyword arguments. Perhaps it'd be better to accept hash as a single positional argument. I wasn't analyzing that.

Apart from codebase itself, some dependencies also aren't compatible with Ruby 3.0 yet:

- ~`bibtex-ruby` (waiting for https://github.com/inukshuk/bibtex-ruby/pull/146)~
- `debase`
- `ruby-debug-ide`

