### PR TITLE
Feature/ruby 3.0.0

### DIFF
--- a/lib/relaton_bib/bibliographic_item.rb
+++ b/lib/relaton_bib/bibliographic_item.rb
@@ -197,23 +197,23 @@ module RelatonBib
       @title = TypedTitleStringCollection.new(args[:title])
 
       @date = (args[:date] || []).map do |d|
-        d.is_a?(Hash) ? BibliographicDate.new(d) : d
+        d.is_a?(Hash) ? BibliographicDate.new(**d) : d
       end
 
       @contributor = (args[:contributor] || []).map do |c|
         if c.is_a? Hash
-          e = c[:entity].is_a?(Hash) ? Organization.new(c[:entity]) : c[:entity]
+          e = c[:entity].is_a?(Hash) ? Organization.new(**c[:entity]) : c[:entity]
           ContributionInfo.new(entity: e, role: c[:role])
         else c
         end
       end
 
       @abstract = (args[:abstract] || []).map do |a|
-        a.is_a?(Hash) ? FormattedString.new(a) : a
+        a.is_a?(Hash) ? FormattedString.new(**a) : a
       end
 
       @copyright = args.fetch(:copyright, []).map do |c|
-        c.is_a?(Hash) ? CopyrightAssociation.new(c) : c
+        c.is_a?(Hash) ? CopyrightAssociation.new(**c) : c
       end
 
       @docidentifier  = args[:docid] || []
@@ -229,7 +229,7 @@ module RelatonBib
       @status         = args[:docstatus]
       @relation       = DocRelationCollection.new(args[:relation] || [])
       @link           = args.fetch(:link, []).map do |s|
-        if s.is_a?(Hash) then TypedUri.new(s)
+        if s.is_a?(Hash) then TypedUri.new(**s)
         elsif s.is_a?(String) then TypedUri.new(content: s)
         else s
         end

--- a/lib/relaton_bib/copyright_association.rb
+++ b/lib/relaton_bib/copyright_association.rb
@@ -30,7 +30,7 @@ module RelatonBib
       end
 
       @owner = owner.map do |o|
-        o.is_a?(Hash) ? ContributionInfo.new(entity: Organization.new(o)) : o
+        o.is_a?(Hash) ? ContributionInfo.new(entity: Organization.new(**o)) : o
       end
 
       @from  = Date.strptime(from.to_s, "%Y") if from.to_s.match? /\d{4}/

--- a/lib/relaton_bib/document_relation_collection.rb
+++ b/lib/relaton_bib/document_relation_collection.rb
@@ -18,7 +18,7 @@ module RelatonBib
     #                   RelatonBib::SourceLocalityStack>] :source_locality
     # @option relation [RelatonBib::BibliographicItem, NillClass] :bibitem (nil)
     def initialize(relation)
-      @array = relation.map { |r| r.is_a?(Hash) ? DocumentRelation.new(r) : r }
+      @array = relation.map { |r| r.is_a?(Hash) ? DocumentRelation.new(**r) : r }
     end
 
     # @todo We don't have replace type anymore. Suppose we should update this

--- a/lib/relaton_bib/document_status.rb
+++ b/lib/relaton_bib/document_status.rb
@@ -54,7 +54,7 @@ module RelatonBib
     # @return [RelatonBib::DocumentStatus::Stage]
     def stage_new(stg)
       if stg.is_a?(Stage) then stg
-      elsif stg.is_a?(Hash) then Stage.new(stg)
+      elsif stg.is_a?(Hash) then Stage.new(**stg)
       elsif stg.is_a?(String) then Stage.new(value: stg)
       end
     end

--- a/lib/relaton_bib/hash_converter.rb
+++ b/lib/relaton_bib/hash_converter.rb
@@ -97,7 +97,7 @@ module RelatonBib
         return unless ret[:place]
 
         ret[:place] = array(ret[:place]).map do |pl|
-          pl.is_a?(String) ? Place.new(name: pl) : Place.new(pl)
+          pl.is_a?(String) ? Place.new(name: pl) : Place.new(**pl)
         end
       end
 
@@ -146,7 +146,7 @@ module RelatonBib
         ret[:biblionote] = array(ret[:biblionote])
           .reduce(BiblioNoteCollection.new([])) do |mem, n|
           mem << if n.is_a?(String) then BiblioNote.new content: n
-                 else BiblioNote.new(n)
+                 else BiblioNote.new(**n)
                  end
         end
       end
@@ -247,10 +247,10 @@ module RelatonBib
                       script: d[:script], format: d[:format] }
                   else { content: d }
                   end
-            FormattedString.new cnt
+            FormattedString.new **cnt
           end
           Affiliation.new(
-            organization: Organization.new(org_hash_to_bib(a[:organization])),
+            organization: Organization.new(**org_hash_to_bib(a[:organization])),
             description: a[:description]
           )
         end
@@ -288,7 +288,7 @@ module RelatonBib
         ret[:relation] = array(ret[:relation])
         ret[:relation]&.each do |r|
           if r[:description]
-            r[:description] = FormattedString.new r[:description]
+            r[:description] = FormattedString.new **r[:description]
           end
           relation_bibitem_hash_to_bib(r)
           relation_locality_hash_to_bib(r)
@@ -309,7 +309,7 @@ module RelatonBib
       # @param item_hash [Hash]
       # @return [RelatonBib::BibliographicItem]
       def bib_item(item_hash)
-        BibliographicItem.new item_hash
+        BibliographicItem.new **item_hash
       end
 
       # @param rel [Hash] relation
@@ -356,26 +356,26 @@ module RelatonBib
           end
           s[:abbreviation] &&
             s[:abbreviation] = localizedstring(s[:abbreviation])
-          Series.new(s)
+          Series.new(**s)
         end
       end
 
       # @param title [Hash]
       # @return [RelatonBib::TypedTitleString]
       def typed_title_strig(title)
-        TypedTitleString.new title
+        TypedTitleString.new **title
       end
 
       # @param ret [Hash]
       def medium_hash_to_bib(ret)
-        ret[:medium] = Medium.new(ret[:medium]) if ret[:medium]
+        ret[:medium] = Medium.new(**ret[:medium]) if ret[:medium]
       end
 
       # @param ret [Hash]
       def classification_hash_to_bib(ret)
         if ret[:classification]
           ret[:classification] = array(ret[:classification]).map do |cls|
-            Classification.new cls
+            Classification.new **cls
           end
         end
       end
@@ -409,7 +409,7 @@ module RelatonBib
         return unless ret[:editorialgroup]
 
         technical_committee = array(ret[:editorialgroup]).map do |wg|
-          TechnicalCommittee.new WorkGroup.new(wg)
+          TechnicalCommittee.new WorkGroup.new(**wg)
         end
         ret[:editorialgroup] = EditorialGroup.new technical_committee
       end
@@ -418,7 +418,7 @@ module RelatonBib
       def ics_hash_to_bib(ret)
         return unless ret[:ics]
 
-        ret[:ics] = array(ret[:ics]).map { |ics| ICS.new ics }
+        ret[:ics] = array(ret[:ics]).map { |ics| ICS.new **ics }
       end
 
       # @param ret [Hash]
@@ -427,7 +427,7 @@ module RelatonBib
 
         sids = array(ret[:structuredidentifier]).map do |si|
           si[:agency] = array si[:agency]
-          StructuredIdentifier.new si
+          StructuredIdentifier.new **si
         end
         ret[:structuredidentifier] = StructuredIdentifierCollection.new sids
       end
@@ -485,7 +485,7 @@ module RelatonBib
       # @return [RelatonBib::FormattedRef]
       def formattedref(frf)
         if frf.is_a?(Hash)
-          RelatonBib::FormattedRef.new(frf)
+          RelatonBib::FormattedRef.new(**frf)
         else
           RelatonBib::FormattedRef.new(content: frf)
         end

--- a/lib/relaton_bib/typed_title_string.rb
+++ b/lib/relaton_bib/typed_title_string.rb
@@ -8,7 +8,7 @@ module RelatonBib
     # @param title [Array<RelatonBib::TypedTitleString, Hash>]
     def initialize(title = [])
       @array = (title || []).map do |t|
-        t.is_a?(Hash) ? TypedTitleString.new(t) : t
+        t.is_a?(Hash) ? TypedTitleString.new(**t) : t
       end
     end
 
@@ -96,7 +96,7 @@ module RelatonBib
         fsargs = args.select do |k, _v|
           %i[content language script format].include? k
         end
-        @title = FormattedString.new(fsargs)
+        @title = FormattedString.new(**fsargs)
       end
     end
 

--- a/lib/relaton_bib/xml_parser.rb
+++ b/lib/relaton_bib/xml_parser.rb
@@ -376,7 +376,7 @@ module RelatonBib
       # @param item_hash [Hash]
       # @return [RelatonBib::BibliographicItem]
       def bib_item(item_hash)
-        BibliographicItem.new item_hash
+        BibliographicItem.new **item_hash
       end
 
       # @param rel [Nokogiri::XML::Element]

--- a/relaton-bib.gemspec
+++ b/relaton-bib.gemspec
@@ -24,11 +24,11 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new(">= 2.4.0")
 
   spec.add_development_dependency "byebug"
-  spec.add_development_dependency "debase"
+  # spec.add_development_dependency "debase"
   spec.add_development_dependency "equivalent-xml", "~> 0.6"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "ruby-debug-ide"
+  # spec.add_development_dependency "ruby-debug-ide"
   spec.add_development_dependency "ruby-jing"
   spec.add_development_dependency "simplecov"
 

--- a/spec/relaton_bib/bibliographic_item_spec.rb
+++ b/spec/relaton_bib/bibliographic_item_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "RelatonBib" => :BibliographicItem do
       hash = YAML.load_file "spec/examples/bib_item.yml"
       hash_bib = RelatonBib::HashConverter.hash_to_bib hash
 
-      RelatonBib::BibliographicItem.new(hash_bib)
+      RelatonBib::BibliographicItem.new(**hash_bib)
     end
 
     it "is instance of BibliographicItem" do
@@ -120,7 +120,7 @@ RSpec.describe "RelatonBib" => :BibliographicItem do
     it "deals with hashes" do
       file = "spec/examples/bib_item.yml"
       h = RelatonBib::HashConverter.hash_to_bib(YAML.load_file(file))
-      b = RelatonBib::BibliographicItem.new(h)
+      b = RelatonBib::BibliographicItem.new(**h)
       expect(b.to_xml).to be_equivalent_to subject.to_xml
     end
 


### PR DESCRIPTION
 - #42 

Some implementation notes:

 - The main problem in the `relaton-bib` is calling methods with keyword arguments with a hash object, this doesn't allow in Ruby 3.0.0, more info here https://stackoverflow.com/questions/65912322/argumenterror-when-upgrading-from-ruby-2-7-to-3-0-related-to-separation-of-pos
 - Temporally I disabled `debase` and `ruby-debug-ide` just to check if tests will pass

General notes:

 - On GH CI we have troubles with the installation of `debase` and `ruby-debug-ide` gems
 - According to the https://github.com/ruby-debug/debase/releases/tag/v0.2.5.beta2 debase should support ruby 3.0.0, but I wasn't able to install it on macOS locally
 - I was able to install both `debase` and `ruby-debug-ide` without any issues in docker, and I have no idea why it works in docker but doesn't on CI yet `docker run -v $(pwd):/relaton-bib -w /relaton-bib ruby:3.0.0 bash -c "gem install bundler; bundle install; bundle exec rake"`

Open questions:

I'm not an expert in ruby at all, maybe you can clarify me:

 - Should we add `debase` and `ruby-debug-ide` at all to gemspec? What is your opinion?
 - I'm not sure that the proposed implementation right one, maybe we should fix it differently