### PR TITLE
Bump nokogiri version to "~> 1.16"

### DIFF
--- a/relaton-bib.gemspec
+++ b/relaton-bib.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "bibtex-ruby"
   spec.add_dependency "htmlentities"
   spec.add_dependency "iso639"
-  spec.add_dependency "nokogiri", "~> 1.15.0"
+  spec.add_dependency "nokogiri", "~> 1.16"
 end


### PR DESCRIPTION
In order to package metanorma on MSys it has to be compatible with gcc 14 which in turn requires nokogiri 1.16