### PR TITLE
Allow <fn> in Sanitizer to preserve footnotes in bibliographic titles

### DIFF
--- a/lib/relaton/bib/sanitizer.rb
+++ b/lib/relaton/bib/sanitizer.rb
@@ -3,12 +3,19 @@ require "nokogiri"
 module Relaton
   module Bib
     # Strips inline markup not in the basicdoc PureTextElement set
-    # (plus <p>, <eref>, <xref>) from raw marked-up content strings.
+    # (plus <p>, <eref>, <xref>, <fn>) from raw marked-up content strings.
     # Disallowed elements are unwrapped: tags removed, inner text kept.
+    #
+    # <fn> is admitted beyond strict PureTextElement because bibliographic
+    # titles in real Metanorma input routinely carry footnotes (e.g. ISO
+    # standards titles with a disclaimer footnote), and downstream
+    # consumers — notably relaton-render's own inline-tag allow-list —
+    # already accept <fn> as a legitimate child of <title>. Stripping it
+    # here would break the round-trip.
     module Sanitizer
       ALLOWED = %w[
         em strong sub sup tt underline strike smallcap br stem
-        p eref xref
+        p eref xref fn
       ].freeze
 
       RENAME = {

--- a/spec/relaton/bib/sanitizer_spec.rb
+++ b/spec/relaton/bib/sanitizer_spec.rb
@@ -80,6 +80,17 @@ describe Relaton::Bib::Sanitizer do
       expected = "values of <em>h</em>, <em>N</em><sub>A</sub>"
       expect(described_class.sanitize(input)).to eq expected
     end
+
+    it "preserves <fn> wrapping a <p> body (footnote in title)" do
+      input = 'Cereals and cereal products' \
+              '<fn reference="7"><p id="_x">ISO is a standards ' \
+              'organisation.</p></fn>'
+      output = described_class.sanitize(input)
+      expect(output).to include('<fn reference="7">')
+      expect(output).to include('<p id="_x">')
+      expect(output).to include('ISO is a standards organisation.')
+      expect(output).to include('</fn>')
+    end
   end
 end
 


### PR DESCRIPTION
## Summary

Adds `<fn>` to `Relaton::Bib::Sanitizer::ALLOWED` so that footnotes embedded in bibliographic titles (and other `LocalizedMarkedUpString` content fields) round-trip through `content=` instead of being unwrapped at assignment time.

## Background — why this matters

The sanitiser landed in [4cfd83b](https://github.com/relaton/relaton-bib/commit/4cfd83b) ("Sanitize LocalizedMarkedUpString#content to basicdoc PureTextElement", referencing relaton/relaton-doi#21) on the `lutaml-integration` branch, shipped in 2.1.2 / 2.1.3. It prepends a `ContentSanitization` module onto the `content=` setter of `LocalizedMarkedUpString`, which is the base class for `Title`, `Note`, `Abstract`, `Formattedref`, `Affiliation`, `Contributor`, `Docidentifier`, etc.

The intent — clamping raw marked-up content to a known-safe inline set — is the right shape of fix. The execution has a gap: `<fn>` is missing from `ALLOWED`, so when a bibitem like

```xml
<title type="main" format="text/plain">Cereals and cereal products<fn reference="7"><p id="_x">ISO is a standards organisation.</p></fn></title>
```

is loaded, the setter unwraps `<fn>` (children kept) and stores

```
"Cereals and cereal products\n  <p id=\"_x\">ISO is a standards organisation.</p>\n"
```

The `<fn>` wrapper is gone before any downstream consumer sees the value.

## Downstream impact — visible regression in isodoc

This causes a real round-trip regression in [metanorma/isodoc](https://github.com/metanorma/isodoc), where the failing test is [`spec/isodoc/footnotes_spec.rb:4`](https://github.com/metanorma/isodoc/blob/main/spec/isodoc/footnotes_spec.rb#L4) ("processes IsoXML footnotes"). The test exercises exactly the ISO pattern of attaching a disclaimer footnote to a standard's title:

```xml
<title type="main" format="text/plain">Cereals and cereal products<fn reference="7"><p>ISO is a standards organisation.</p></fn></title>
```

With the current 2.1.3 sanitiser the expected formattedref

```xml
<em>Cereals and cereal products<fn reference="4" ...><p>ISO is a standards organisation.</p>...</fn></em>
```

degrades to

```xml
<em>Cereals and cereal products ISO is a standards organisation.</em>
```

— footnote stripped, content inlined as plain text. This also shifts every subsequent footnote number in the document (the title fn was reference 4, so all later references decrement).

The chain is:

1. relaton-bib `Sanitizer` (this gem) strips `<fn>` at `content=` time because `fn` is not in `ALLOWED`. The orphan `<p>` survives.
2. relaton-render's own inline-tag sanitiser ([parse.rb:123, allow-list at parse.rb:85-90](https://github.com/relaton/relaton-render/blob/main/lib/relaton/render/parse/parse.rb#L85)) then strips the orphan `<p>` (which isn't in *its* allow-list) and the `gsub` chain in `content()` collapses the residual whitespace.
3. The text content of the original `<fn>` ends up concatenated into the surrounding `<em>`.

Notably, relaton-render's own allow-list (extended in [relaton-render PR #76 / commit 27fde10](https://github.com/relaton/relaton-render/commit/27fde10)) does include `<fn>` — that gem was correctly preserving footnotes inside titles before relaton-bib started pre-emptively stripping them.

I'm absorbing this regression downstream for the current release rather than blocking, but flagging it so the relaton-bib allow-list can catch up.

## Grammar context

The strict basicdoc grammar's `PureTextElement` ([basicdoc.rng:1292-1308](https://github.com/relaton/relaton-bib/blob/lutaml-integration/spec/schemas/basicdoc.rng#L1292)) is:

```
text | em | strong | sub | sup | tt | underline | strike | smallcap | br | stem
```

`<fn>` is not in it. Strictly, then, `<fn>` inside `<title>` (which biblio.rng pipes through `LocalizedMarkedUpString` → `oneOrMore PureTextElement`) is non-conformant.

In practice it has been routinely produced by isodoc/metanorma for years — ISO standards titles with disclaimer footnotes are a stock pattern. The existing sanitiser already concedes this kind of practical broadening: the commit message says "basicdoc PureTextElement set (plus `<p>`, `<eref>`, `<xref>`)" — none of which is in strict PureTextElement either. `<p>` in particular is the inverse of `<fn>`: strictly it's a block, not an inline, but it has to be allowed because `Abstract` content is paragraph-shaped.

This PR proposes the same kind of carve-out for `<fn>` on the same grounds: it's a real element that real bibliographic input carries, and it's already accepted by downstream consumers.

## Open question for follow-up

This is the minimum change to restore the title-fn round-trip. Other Metanorma inline elements that relaton-render's allow-list permits but relaton-bib's does not — `link`, `bookmark`, `image`, `index`, `index-xref`, `concept`, `keyword`, `add`, `del`, `span`, `pagebreak`, `hr`, `erefstack`, `date`, `ruby` — may or may not warrant similar treatment depending on whether they show up in real bibliographic content. I haven't audited that and don't want to broaden the allow-list speculatively in this PR. Worth a separate look.

## Changes

- `lib/relaton/bib/sanitizer.rb` — add `fn` to `ALLOWED`; update the header comment to document the carve-out.
- `spec/relaton/bib/sanitizer_spec.rb` — add a test case asserting that `<fn>` with nested `<p>` body survives sanitisation (the existing per-tag preservation loop also automatically covers the bare `<fn>x</fn>` case via `ALLOWED.each`).

## Test plan

- [x] `bundle exec rspec spec/relaton/bib/sanitizer_spec.rb` — 33/33 pass on `fix/sanitizer-allow-fn`
- [x] With isodoc pointed at this branch via `Gemfile.devel`, `spec/isodoc/footnotes_spec.rb:4` passes (4/4 examples)
- [ ] Full relaton-bib suite — would appreciate CI confirmation
- [ ] Downstream relaton-render and other relaton-consumers — no expected impact since this only *adds* a tag to the allow-list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
