### PR TITLE
fix: preserve opaque <stem> contents in Sanitizer (MathML round-trip)

### DIFF
--- a/lib/relaton/bib/sanitizer.rb
+++ b/lib/relaton/bib/sanitizer.rb
@@ -12,11 +12,23 @@ module Relaton
     # consumers — notably relaton-render's own inline-tag allow-list —
     # already accept <fn> as a legitimate child of <title>. Stripping it
     # here would break the round-trip.
+    #
+    # OPAQUE elements (currently <stem>) are also allowed, but the
+    # sanitiser does not descend into them: their contents are out-of-band
+    # inline notation (MathML, AsciiMath, LaTeX) rather than basicdoc
+    # markup, and must be preserved verbatim. Without the opaque-skip,
+    # the recursive walk would unwrap MathML / AsciiMath elements down to
+    # bare text nodes — see #116 for the round-trip-loss symptom.
     module Sanitizer
       ALLOWED = %w[
         em strong sub sup tt underline strike smallcap br stem
         p eref xref fn
       ].freeze
+
+      # Elements whose children are non-basicdoc inline notation
+      # (MathML, AsciiMath, LaTeX, …) and must be preserved verbatim
+      # rather than sanitised against ALLOWED.
+      OPAQUE = %w[stem].freeze
 
       RENAME = {
         "italic" => "em",
@@ -44,6 +56,8 @@ module Relaton
           next unless child.element?
 
           child.name = RENAME[child.name] if RENAME.key?(child.name)
+          next if OPAQUE.include?(child.name)
+
           sanitize_children(child)
           child.replace(child.children) unless ALLOWED.include?(child.name)
         end

--- a/spec/relaton/bib/sanitizer_spec.rb
+++ b/spec/relaton/bib/sanitizer_spec.rb
@@ -91,6 +91,53 @@ describe Relaton::Bib::Sanitizer do
       expect(output).to include('ISO is a standards organisation.')
       expect(output).to include('</fn>')
     end
+
+    # Opaque-stem cases (#116): <stem> holds out-of-band notation
+    # (MathML, AsciiMath, LaTeX) that the sanitiser must preserve
+    # rather than recurse into. Assertions are include-shaped because
+    # Nokogiri's serialiser may reflow whitespace around nested
+    # elements; the SEMANTIC claim is "inner elements survive, not just
+    # their text content".
+    it "preserves MathML inner elements inside <stem> (does not unwrap to text)" do
+      input  = 'Prefix <stem><math><mi>d</mi><mn>6</mn></math>' \
+               '<asciimath>d_6</asciimath></stem> Suffix'
+      output = described_class.sanitize(input)
+      expect(output).to include("<math>")
+      expect(output).to include("<mi>d</mi>")
+      expect(output).to include("<mn>6</mn>")
+      expect(output).to include("<asciimath>d_6</asciimath>")
+      # Negative: pre-fix the inner elements were unwrapped to bare
+      # text, producing "<stem>d6d_6</stem>". Make sure that exact
+      # collapsed shape does not reappear.
+      expect(output).not_to match(/<stem>\s*d\s*6\s*d_6\s*<\/stem>/)
+    end
+
+    it "preserves <stem> attributes alongside opaque MathML content" do
+      input  = 'a-<stem block="false" type="MathML">' \
+               '<math xmlns="http://www.w3.org/1998/Math/MathML">' \
+               '<mstyle displaystyle="false"><msub><mi>d</mi><mn>6</mn>' \
+               '</msub></mstyle></math><asciimath>d_6</asciimath>' \
+               '</stem> [ISRD-07]'
+      output = described_class.sanitize(input)
+      expect(output).to include('<stem block="false" type="MathML">')
+      expect(output).to include('<mstyle displaystyle="false">')
+      expect(output).to include('<msub>')
+      expect(output).to include('<mi>d</mi>')
+      expect(output).to include('<mn>6</mn>')
+      expect(output).to include('<asciimath>d_6</asciimath>')
+      expect(output).to include('[ISRD-07]')
+    end
+
+    it "still sanitises siblings of <stem> while leaving stem opaque" do
+      input  = '<script>bad</script> a-<stem><math><mi>x</mi></math>' \
+               '</stem> <em>ok</em>'
+      output = described_class.sanitize(input)
+      expect(output).not_to include("<script>")
+      expect(output).to include("bad ")
+      expect(output).to include("<math>")
+      expect(output).to include("<mi>x</mi>")
+      expect(output).to include("<em>ok</em>")
+    end
   end
 end
 


### PR DESCRIPTION
Closes https://github.com/relaton/relaton-bib/issues/116

See the linked issue for the full diagnosis, reproducer, and root-cause walk-through. This PR is the proposed fix.

## Change

`lib/relaton/bib/sanitizer.rb`:

- New `OPAQUE = %w[stem].freeze` set, listing elements whose children are non-basicdoc inline notation (MathML, AsciiMath, LaTeX, …) and must be preserved verbatim rather than sanitised against `ALLOWED`.
- `sanitize_children` short-circuits before recursing into OPAQUE elements (after the `RENAME` pass, before the recursive descent), so their inner XML survives the walk untouched.

`spec/relaton/bib/sanitizer_spec.rb`:

- Three new examples covering the opaque-`<stem>` cases — MathML inner elements survive, `<stem>` attributes plus deeply nested MathML survive, and siblings of `<stem>` are still sanitised (opacity is local).
- Assertions use `include`-style matches because Nokogiri's serialiser may reflow whitespace around nested elements; the semantic claim is "inner elements survive, not just their text content".

## Verification

`bundle exec rspec spec/relaton/bib/sanitizer_spec.rb` → **36 examples, 0 failures**.

## Target branch

`lutaml-integration` — the 2.x line lives on this branch (`main` is still 1.x, last tagged v1.20.8).

## Downstream

The regression that prompted this fix is in [`metanorma/metanorma-generic`](https://github.com/metanorma/metanorma-generic) — the spec `Metanorma::Generic::BibdataConfig preserves embedded MathML when deserialising a bibdata title` fails until this lands and a new `relaton-bib` release ships. No `Gemfile.devel` pointer is being added to `metanorma-generic` because there is no `metanorma-generic` release pending this cycle; the metanorma-generic spec stays red until the next release-cycle gem bump.

🤖
