### PR TITLE
Assert MathML namespace survives in opaque-stem Sanitizer test

### DIFF
--- a/spec/relaton/bib/sanitizer_spec.rb
+++ b/spec/relaton/bib/sanitizer_spec.rb
@@ -120,6 +120,13 @@ describe Relaton::Bib::Sanitizer do
                '</stem> [ISRD-07]'
       output = described_class.sanitize(input)
       expect(output).to include('<stem block="false" type="MathML">')
+      # The MathML namespace must survive verbatim -- the whole point of
+      # basicdoc-models#35 ("namespace and all"). lutaml-model (0.8.16)
+      # preserves it through the map_all raw round-trip in both XML and
+      # key-value; this guards the Sanitizer half, and would fail loudly if
+      # the opaque-stem handling (#116/#117) were reverted.
+      expect(output)
+        .to include('<math xmlns="http://www.w3.org/1998/Math/MathML">')
       expect(output).to include('<mstyle displaystyle="false">')
       expect(output).to include('<msub>')
       expect(output).to include('<mi>d</mi>')


### PR DESCRIPTION
Refs https://github.com/relaton/relaton-bib/issues/116
Refs https://github.com/metanorma/basicdoc-models/issues/35

The opaque-stem Sanitizer test (#117) already fed a namespaced `<math xmlns="http://www.w3.org/1998/Math/MathML">`, but only asserted the *inner elements* survived — not the **namespace** itself. basicdoc-models#35 makes MathML an explicit, namespaced grammar, so the `xmlns` surviving the round-trip is the actual requirement ("namespace and all").

This adds the missing assertion. Verified separately that **lutaml-model 0.8.16** preserves the `xmlns` through `map_all raw` in both XML and key-value round-trips, so the model half needs no change — this guards the Sanitizer half, and would fail loudly if the opaque-stem handling (#116/#117) were reverted.

🤖
